### PR TITLE
Update mswss-infrastructure-static.radl

### DIFF
--- a/IM/mswss-infrastructure-static.radl
+++ b/IM/mswss-infrastructure-static.radl
@@ -72,21 +72,21 @@ configure front (
     nfs_mode: front
     role: grycap.nfs
     when: QUEUE_SYSTEM != 'local'
-  - max_number_of_nodes: '{{NNODES}}'
-    role: grycap.slurm
-    slurm_type_of_node: front
-    slurm_wn_nodenames: '{{ groups["wn"]|map("extract", hostvars, "ansible_hostname")|list if "wn" in groups else [] }}'
-    slurm_vnode_prefix: vnode-
-    templates: '{{TEMPLATES}}'
-  - galaxy_export_dir: /home/export
-    galaxy_lrms: '{{ QUEUE_SYSTEM }}'
-    galaxy_slurm_server_name: '{{ hostvars[groups["front"][0]]["IM_NODE_PRIVATE_IP"]
-      }}'
-    role: grycap.galaxy
-    slurm_galaxy_docker_env_vars:
-      GALAXY_CONFIG_JOB_CONFIG_FILE: /export/slurm_job_conf.xml
-      GALAXY_DESTINATIONS_DEFAULT: slurm_cluster
-      NONUSE: reports,slurmctld,nodejs,condor,slurmd
+#  - max_number_of_nodes: '{{NNODES}}'
+#    role: grycap.slurm
+#    slurm_type_of_node: front
+#    slurm_wn_nodenames: '{{ groups["wn"]|map("extract", hostvars, "ansible_hostname")|list if "wn" in groups else [] }}'
+#    slurm_vnode_prefix: vnode-
+#    templates: '{{TEMPLATES}}'
+#  - galaxy_export_dir: /home/export
+#    galaxy_lrms: '{{ QUEUE_SYSTEM }}'
+#    galaxy_slurm_server_name: '{{ hostvars[groups["front"][0]]["IM_NODE_PRIVATE_IP"]
+#      }}'
+#    role: grycap.galaxy
+#    slurm_galaxy_docker_env_vars:
+#      GALAXY_CONFIG_JOB_CONFIG_FILE: /export/slurm_job_conf.xml
+#      GALAXY_DESTINATIONS_DEFAULT: slurm_cluster
+#      NONUSE: reports,slurmctld,nodejs,condor,slurmd
   vars:
     NNODES: 1
     QUEUE_SYSTEM: slurm
@@ -191,14 +191,14 @@ configure wn (
       server_host: '{{ FRONTEND }}'
     nfs_mode: wn
     role: grycap.nfs
-  - galaxy_export_dir: /home/export
-    galaxy_node_type: wn
-    role: grycap.galaxy
+#  - galaxy_export_dir: /home/export
+#    galaxy_node_type: wn
+#    role: grycap.galaxy
   vars:
     FRONTEND: slurmserver
-- roles:
-  - role: grycap.slurm
-    slurm_type_of_node: wn
+#- roles:
+#  - role: grycap.slurm
+#    slurm_type_of_node: wn
 
 
 @end


### PR DESCRIPTION
Configuration of Slurm and Galaxy temporarily disabled to make the testing shorter in order to avoid issues with short lifetime of the access token.